### PR TITLE
Fix path for Windows when spaces in the file path

### DIFF
--- a/jill/install.py
+++ b/jill/install.py
@@ -151,7 +151,7 @@ def make_symlinks(src_bin, symlink_dir, version):
         if current_system() == "windows":
             with open(linkpath, 'w') as f:
                 # create a cmd file to mimic how we do symlinks in linux
-                f.writelines(["@echo off\n", f"{src_bin} %*"])
+                f.writelines(["@echo off\n", f"\"{src_bin}\" %*"])
         else:
             os.symlink(src_bin, linkpath)
 


### PR DESCRIPTION
My computer has a space in the username. This means that when trying to run julia after installing with jill, I get the error
``` 
'C:\Users\Michael' is not recognized as an internal or external command,
operable program or batch file.
```

Hopefully by adding quotes around the path to julia, this fixes the issue.